### PR TITLE
Forecasting

### DIFF
--- a/superset/assets/src/explore/controlPanels/Line.js
+++ b/superset/assets/src/explore/controlPanels/Line.js
@@ -36,6 +36,15 @@ export default {
     },
     NVD3TimeSeries[1],
     annotations,
+    {
+      label: t('Forecasting options'),
+      expanded: false,
+      controlSetRows: [
+        ['forecasting_enable'],
+        ['forecasting_horizon'],
+        ['forecasting_interval'],
+      ],
+    },
   ],
   controlOverrides: {
     x_axis_format: {

--- a/superset/assets/src/explore/controlPanels/Line.js
+++ b/superset/assets/src/explore/controlPanels/Line.js
@@ -1,6 +1,7 @@
 import { t } from '@superset-ui/translation';
 import { NVD3TimeSeries, annotations } from './sections';
 import { D3_TIME_FORMAT_OPTIONS } from '../controls';
+import forecastingSection from '../../forecasting/sections';
 
 export default {
   requiresTime: true,
@@ -36,15 +37,7 @@ export default {
     },
     NVD3TimeSeries[1],
     annotations,
-    {
-      label: t('Forecasting options'),
-      expanded: false,
-      controlSetRows: [
-        ['forecasting_enable'],
-        ['forecasting_horizon'],
-        ['forecasting_interval'],
-      ],
-    },
+    forecastingSection,
   ],
   controlOverrides: {
     x_axis_format: {

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -2281,5 +2281,38 @@ export const controls = {
     description: t('Whether to normalize the histogram'),
     default: false,
   },
+
+  forecasting_enable: {
+    type: 'CheckboxControl',
+    label: t('Enable forecasting'),
+    renderTrigger: true,
+    description: t('Enable forecasting for the current data'),
+    default: false,
+  },
+
+  forecasting_horizon: {
+    type: 'TextControl',
+    isInt: true,
+    validators: [v.integer, v.nonEmpty],
+    renderTrigger: false,
+    default: (props) => {
+      console.log('PROPS', props);
+      return 2;
+    },
+    label: t('Confidence'),
+    description: t('Forecasting horizon confidence'),
+    mapStateToProps: state => state,
+  },
+
+  forecasting_interval: {
+    type: 'TextControl',
+    isInt: true,
+    validators: [v.integer, v.nonEmpty],
+    renderTrigger: false,
+    default: 2,
+    label: t('Confidence'),
+    description: t('Forecasting horizon confidence'),
+  },
+
 };
 export default controls;

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -52,6 +52,8 @@ import { defaultViewport } from '../modules/geo';
 import ColumnOption from '../components/ColumnOption';
 import OptionDescription from '../components/OptionDescription';
 
+import forecastingControls from '../forecasting/controls';
+
 const categoricalSchemeRegistry = getCategoricalSchemeRegistry();
 const sequentialSchemeRegistry = getSequentialSchemeRegistry();
 
@@ -2282,36 +2284,7 @@ export const controls = {
     default: false,
   },
 
-  forecasting_enable: {
-    type: 'CheckboxControl',
-    label: t('Enable forecasting'),
-    renderTrigger: true,
-    description: t('Enable forecasting for the current data'),
-    default: false,
-  },
-
-  forecasting_horizon: {
-    type: 'TextControl',
-    isInt: true,
-    validators: [v.integer, v.nonEmpty],
-    renderTrigger: false,
-    default: (props) => {
-      return 2;
-    },
-    label: t('Confidence'),
-    description: t('Forecasting horizon confidence'),
-    mapStateToProps: state => state,
-  },
-
-  forecasting_interval: {
-    type: 'TextControl',
-    isInt: true,
-    validators: [v.integer, v.nonEmpty],
-    renderTrigger: false,
-    default: 80,
-    label: t('Confidence %'),
-    description: t('Forecasting horizon confidence in %'),
-  },
+  ...forecastingControls,
 
 };
 export default controls;

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -2296,7 +2296,6 @@ export const controls = {
     validators: [v.integer, v.nonEmpty],
     renderTrigger: false,
     default: (props) => {
-      console.log('PROPS', props);
       return 2;
     },
     label: t('Confidence'),
@@ -2309,9 +2308,9 @@ export const controls = {
     isInt: true,
     validators: [v.integer, v.nonEmpty],
     renderTrigger: false,
-    default: 2,
-    label: t('Confidence'),
-    description: t('Forecasting horizon confidence'),
+    default: 80,
+    label: t('Confidence %'),
+    description: t('Forecasting horizon confidence in %'),
   },
 
 };

--- a/superset/assets/src/forecasting/client.js
+++ b/superset/assets/src/forecasting/client.js
@@ -1,0 +1,57 @@
+import delphiReponse from './delphi-response';
+
+const forecastingSeries = [
+  'forecasting:forecast',
+  'forecasting:lower',
+  'forecasting:upper',
+];
+
+/**
+ * Validates forecasting flags and if conditions are met it will query delphi
+ * @param response
+ * @returns {Promise<{[p: string]: *}>}
+ */
+export const mutator = (response) => {
+  // if (data)
+  const { form_data = {}, data = [] } = response;
+
+  // we only perform forecasting on the first series
+  const series = data[0];
+  let newData = [...data];
+
+  if (series && form_data.forecasting_enable) {
+    const { values } = series;
+    if (values.length > 0) {
+      const lastActualSeriesPoint = series.values[series.values.length - 1];
+      // create forecasting series placeholder values
+      // we are generating new series for forecasting
+      newData = forecastingSeries.reduce((allSeries, key) => [
+        ...allSeries,
+        {
+          key,
+          values: values.map(({ x }, index) => ({
+            x,
+            y: index === values.length - 1 ? lastActualSeriesPoint.y : null,
+          })),
+        },
+      ], newData);
+
+      // for each series create a fake value having the same value as the previous one
+      newData = newData.map(track => ({
+        key: track.key,
+        values: [
+          ...track.values,
+          ...delphiReponse.data.map(v => ({
+            x: Date.parse(v.Datetime),
+            y: track.key.includes('forecasting') ? v[track.key] : null,
+          })),
+        ],
+      }));
+    }
+  }
+
+  return Promise.resolve({
+    ...response,
+    data: newData,
+  });
+};

--- a/superset/assets/src/forecasting/client.js
+++ b/superset/assets/src/forecasting/client.js
@@ -12,15 +12,17 @@ const forecastingSeries = [
  * @returns {Promise<{[p: string]: *}>}
  */
 export const mutator = (response) => {
-  const { form_data = {}, data = [] } = response;
+  const { form_data: formData = {}, data = [] } = response;
 
   // we only perform forecasting on the first series
   const series = data[0];
   let newData = [...data];
 
-  if (series && form_data.forecasting_enable) {
+  if (series && formData.forecasting_enable) {
     const { values } = series;
     if (values.length > 0) {
+      const { forecasting_horizon: forecastingHorizon = 1 } = formData;
+
       const lastActualSeriesPoint = series.values[series.values.length - 1];
       // create forecasting series placeholder values
       // we are generating new series for forecasting
@@ -35,12 +37,14 @@ export const mutator = (response) => {
         },
       ], newData);
 
+      const forecastingData = delphiReponse.data.slice(0, forecastingHorizon);
+
       // for each series create a fake value having the same value as the previous one
       newData = newData.map(track => ({
         key: track.key,
         values: [
           ...track.values,
-          ...delphiReponse.data.map(v => ({
+          ...forecastingData.map(v => ({
             x: Date.parse(v.Datetime),
             y: track.key.includes('forecasting') ? v[track.key] : null,
           })),

--- a/superset/assets/src/forecasting/client.js
+++ b/superset/assets/src/forecasting/client.js
@@ -12,7 +12,6 @@ const forecastingSeries = [
  * @returns {Promise<{[p: string]: *}>}
  */
 export const mutator = (response) => {
-  // if (data)
   const { form_data = {}, data = [] } = response;
 
   // we only perform forecasting on the first series

--- a/superset/assets/src/forecasting/controls.js
+++ b/superset/assets/src/forecasting/controls.js
@@ -5,30 +5,30 @@ export default {
   forecasting_enable: {
     type: 'CheckboxControl',
     label: t('Enable forecasting'),
-    renderTrigger: true,
+    renderTrigger: false,
     description: t('Enable forecasting for the current data'),
     default: false,
   },
 
   forecasting_horizon: {
-    type: 'TextControl',
+    type: 'SliderControl',
     isInt: true,
     validators: [v.integer, v.nonEmpty],
     renderTrigger: false,
-    default: (props) => {
-      // this should be computed based on the number of points of the original charts
-      return 2;
-    },
+    min: 1,
+    max: 6,
     label: t('Horizon'),
     description: t('Forecasting horizon step'),
     mapStateToProps: state => state,
   },
 
   forecasting_interval: {
-    type: 'TextControl',
+    type: 'SliderControl',
     isInt: true,
     validators: [v.integer, v.nonEmpty],
     renderTrigger: false,
+    min: 1,
+    max: 99,
     default: 80,
     label: t('Confidence %'),
     description: t('Forecasting horizon confidence in %'),

--- a/superset/assets/src/forecasting/controls.js
+++ b/superset/assets/src/forecasting/controls.js
@@ -1,0 +1,36 @@
+import { t } from '@superset-ui/translation';
+import * as v from '../explore/validators';
+
+export default {
+  forecasting_enable: {
+    type: 'CheckboxControl',
+    label: t('Enable forecasting'),
+    renderTrigger: true,
+    description: t('Enable forecasting for the current data'),
+    default: false,
+  },
+
+  forecasting_horizon: {
+    type: 'TextControl',
+    isInt: true,
+    validators: [v.integer, v.nonEmpty],
+    renderTrigger: false,
+    default: (props) => {
+      // this should be computed based on the number of points of the original charts
+      return 2;
+    },
+    label: t('Horizon'),
+    description: t('Forecasting horizon step'),
+    mapStateToProps: state => state,
+  },
+
+  forecasting_interval: {
+    type: 'TextControl',
+    isInt: true,
+    validators: [v.integer, v.nonEmpty],
+    renderTrigger: false,
+    default: 80,
+    label: t('Confidence %'),
+    description: t('Forecasting horizon confidence in %'),
+  },
+};

--- a/superset/assets/src/forecasting/delphi-response.js
+++ b/superset/assets/src/forecasting/delphi-response.js
@@ -24,5 +24,17 @@ export default {
       'forecasting:lower': 16.947618678010087,
       'forecasting:upper': 69.58136270540608,
     },
+    {
+      Datetime: '2015-10-04T22:00:00Z',
+      'forecasting:forecast': 37.50254738920206,
+      'forecasting:lower': 5.136441614219757,
+      'forecasting:upper': 69.86865316418437,
+    },
+    {
+      Datetime: '2015-10-04T07:00:00Z',
+      'forecasting:forecast': 42.617215165808275,
+      'forecasting:lower': 3.4214691866050586,
+      'forecasting:upper': 81.81296114501151,
+    },
   ],
 };

--- a/superset/assets/src/forecasting/delphi-response.js
+++ b/superset/assets/src/forecasting/delphi-response.js
@@ -1,0 +1,28 @@
+export default {
+  data: [
+    {
+      Datetime: '2015-10-01T07:00:00Z',
+      'forecasting:forecast': 32.47064841167762,
+      'forecasting:lower': 19.888155906968947,
+      'forecasting:upper': 45.05314091638631,
+    },
+    {
+      Datetime: '2015-10-02T07:00:00Z',
+      'forecasting:forecast': 35.43333238960573,
+      'forecasting:lower': 18.88316130982956,
+      'forecasting:upper': 51.9835034693819,
+    },
+    {
+      Datetime: '2015-10-03T07:00:00Z',
+      'forecasting:forecast': 32.47064841167762,
+      'forecasting:lower': 27.060319880393337,
+      'forecasting:upper': 69.68848554118834,
+    },
+    {
+      Datetime: '2015-10-04T07:00:00Z',
+      'forecasting:forecast': 43.26449069170808,
+      'forecasting:lower': 16.947618678010087,
+      'forecasting:upper': 69.58136270540608,
+    },
+  ],
+};

--- a/superset/assets/src/forecasting/sections.js
+++ b/superset/assets/src/forecasting/sections.js
@@ -1,0 +1,11 @@
+import { t } from '@superset-ui/translation';
+
+export default {
+  label: t('Forecasting options'),
+  expanded: false,
+  controlSetRows: [
+    ['forecasting_enable'],
+    ['forecasting_horizon'],
+    ['forecasting_interval'],
+  ],
+};


### PR DESCRIPTION
This pull request shows a proof of concept on how to enhance superset to use async data mutators after receiving data from the back end.

In this particular scenario I have created a new control panel in Line chart where users can define forecasting settings.

In order to simulate delphi service to retrieve forecasting data I am using mocked data stored in a file.

![superset_forecasting](https://user-images.githubusercontent.com/2554552/50222038-468b7380-0397-11e9-8d73-1c0e20823c1b.gif)
